### PR TITLE
adding mark.js option to search by whole phrase 

### DIFF
--- a/public/js/home-footer.js
+++ b/public/js/home-footer.js
@@ -3,6 +3,7 @@ var MARK_OPTIONS = {
   // see docs on https://markjs.io#mark
   element: "span",
   className: "marked",
+  separateWordSearch: false,
   accuracy: "exactly"
 };
 var highlightIndex = 0, highlightCount = 0;


### PR DESCRIPTION
Currently, a search for "transfer of information" highlights "of" separate from that whole phrase. I'm setting mark.js `separateWordSearch` to false to target full phrase instead. 
